### PR TITLE
fix(ci): resolve clippy needless borrow and compiler dead_code errors…

### DIFF
--- a/shift_core/src/main.rs
+++ b/shift_core/src/main.rs
@@ -656,7 +656,7 @@ fn process_vault_command(command: &str) -> String {
                 let hash1 = sha_hasher1.finalize();
 
                 let mut sha_hasher2 = Sha256::new();
-                sha_hasher2.update(&hash1);
+                sha_hasher2.update(hash1);
                 let final_hash = sha_hasher2.finalize();
                 cryptogram = hex::encode(final_hash);
             }

--- a/shift_core/src/zk_engine.rs
+++ b/shift_core/src/zk_engine.rs
@@ -40,6 +40,7 @@ impl<F: Field> ConstraintSynthesizer<F> for RideCircuit<F> {
 // =========================================================================
 
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct DistanceBoundingCircuit<F: PrimeField> {
     pub delta_t_nanos: Option<F>,        
     pub t_compute_nanos: Option<F>,      

--- a/shift_core/src/zk_prover.rs
+++ b/shift_core/src/zk_prover.rs
@@ -34,6 +34,7 @@ pub fn pre_initialize_keys() {
     }
 }
 
+#[allow(dead_code)]
 pub fn generate_tof_proof(delta_t_nanos: u64, t_compute_nanos: u64, max_distance_mm: u64) -> String {
     info!("🧠 [zkVM] Spinning up Groth16 Prover using RAM static parameters...");
     


### PR DESCRIPTION
… in production build

Fixed sha_hasher2.update needlessly borrowing hash1 and allowed dead_code on DistanceBoundingCircuit and generate_tof_proof when compiling without simulated feature.